### PR TITLE
fix: preserve jwt.body property for claims accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0
+
+### Breaking Changes
+
+- [#8](https://github.com/okta/okta-jwt-verifier-js/pull/8) - Converts Jwt.claims to read-only property
+
 # 2.3.0
 
 ### Features

--- a/lib.js
+++ b/lib.js
@@ -17,6 +17,9 @@ class ConfigurationValidationError extends Error {}
 
 const findDomainURL = 'https://bit.ly/finding-okta-domain';
 const findAppCredentialsURL = 'https://bit.ly/finding-okta-app-credentials';
+const njwtTokenBodyMethods = [
+  'setClaim', 'setJti', 'setSubject', 'setIssuer', 'setIssuedAt',
+  'setExpiration', 'setNotBefore', 'isExpired', 'isNotBefore'];
 
 const assertIssuer = (issuer, testing = {}) => {
   const isHttps = new RegExp('^https://');
@@ -204,9 +207,20 @@ class OktaJwtVerifier {
           return reject(err);
         }
 
-        jwt.claims = jwt.body;
-        delete jwt.body;
+        const jwtBodyProxy = new Proxy(jwt.body, {});
+        Object.defineProperty(jwt, 'claims', {
+          enumerable: true,
+          writable: false,
+          value: jwtBodyProxy
+        });
 
+        njwtTokenBodyMethods.forEach(methodName => {
+          let method = jwt[methodName];
+          if (method) {
+            jwt[methodName] = method.bind({ body: jwtBodyProxy });
+          }
+        });
+        delete jwt.body;
         resolve(jwt);
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/jwt-verifier",
   "private": true,
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "Easily validate Okta access tokens",
   "repository": "https://github.com/okta/okta-jwt-verifier-js",
   "homepage": "https://github.com/okta/okta-jwt-verifier-js",


### PR DESCRIPTION
Resolves https://github.com/okta/okta-jwt-verifier-js/issues/7

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: OKTA-454520

## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

