### PR TITLE
feat: Pass requestAgentOptions through to the jwks-rsa library

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -9,6 +9,9 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+import { AgentOptions as HttpAgentOptions } from "node:http";
+import { AgentOptions as HttpsAgentOptions } from "node:https";
+
 export = OktaJwtVerifier;
 
 declare class OktaJwtVerifier {
@@ -98,13 +101,22 @@ declare namespace OktaJwtVerifier {
     jwksRequestsPerMinute?: number;
     /**
      * Custom JWKS URI
-     * 
+     *
      * It's useful when JWKS URI cannot be based on Issuer URI
      * Defaults to `${issuer}/v1/keys`
-     * 
+     *
      * Read more: https://github.com/okta/okta-jwt-verifier-js#custom-jwks-uri
      */
     jwksUri?: string;
+
+    /**
+     * Additional options to pass to the jwks-rsa constructor
+     *
+     * Can be used to configure the underlying axios agent within the jwks-rsa library,
+     * for example to add additional certificate authorities without having to set the
+     * NODE_EXTRA_CA_CERTS environment variable.
+     */
+    requestAgentOptions?: HttpAgentOptions | HttpsAgentOptions;
   }
 
   type Algorithm =

--- a/lib.js
+++ b/lib.js
@@ -184,6 +184,7 @@ class OktaJwtVerifier {
       cacheMaxEntries: 3,
       jwksRequestsPerMinute: options.jwksRequestsPerMinute || 10,
       rateLimit: true,
+      requestAgentOptions: options.requestAgentOptions,
     });
     this.verifier = nJwt.createVerifier().setSigningAlgorithm('RS256').withKeyResolver((kid, cb) => {
       if (kid) {


### PR DESCRIPTION
NON-BREAKING: this adds an optional configuration parameter to the OktaJwtVerifier constructor, which in turn is passed
to the jwksClient constructor. Internally, those options are passed on to Axios, thus giving us the ability to configure the
https agent used to fetch the JWKs, for example if we need to trust a specific certification authority.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A?] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

In situations where standard https agent configuration is insufficient, for example when using custom certificate authorities, it is not possible to pass additional options from the jwt verifier library through to the jwks-rsa library, and hence on to the underlying axis instance. In these circumstances, the only way to ensure that the request will succeed is by manipulating environment variables.

Issue Number: N/A


## What is the new behavior?

The added requestAgentOptions parameter on the OktaJwtVerifier constructor is included as one of the constructor parameters on the jwks-rsa library, meaning that we can configure the http agent directly without resorting to environment variables.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information


## Reviewers

