### PR TITLE
feat: add support for `requestAgent`

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -11,8 +11,14 @@
  */
 
 /* eslint-disable node/no-missing-import */
-import { AgentOptions as HttpAgentOptions } from "node:http";
-import { AgentOptions as HttpsAgentOptions } from "node:https";
+import { 
+  AgentOptions as HttpAgentOptions,
+  Agent as HttpAgent,
+} from "node:http";
+import { 
+  AgentOptions as HttpsAgentOptions,
+  Agent as HttpsAgent,
+} from "node:https";
 /* eslint-enable node/no-missing-import */
 
 export = OktaJwtVerifier;
@@ -118,8 +124,16 @@ declare namespace OktaJwtVerifier {
      * Can be used to configure the underlying axios agent within the jwks-rsa library,
      * for example to add additional certificate authorities without having to set the
      * NODE_EXTRA_CA_CERTS environment variable.
+     * 
+     * @deprecated use `requestAgent` instead
      */
     requestAgentOptions?: HttpAgentOptions | HttpsAgentOptions;
+
+    /**
+     * HttpAgent or HttpsAgent to use for requests to the JWKS endpoint. 
+     * Agent example: https://github.com/TooTallNate/node-https-proxy-agent
+     */
+    requestAgent?: HttpAgent | HttpsAgent;
   }
 
   type Algorithm =

--- a/lib.d.ts
+++ b/lib.d.ts
@@ -119,18 +119,11 @@ declare namespace OktaJwtVerifier {
     jwksUri?: string;
 
     /**
-     * Additional options to pass to the jwks-rsa constructor
-     *
-     * Can be used to configure the underlying axios agent within the jwks-rsa library,
-     * for example to add additional certificate authorities without having to set the
-     * NODE_EXTRA_CA_CERTS environment variable.
+     * HttpAgent or HttpsAgent to use for requests to the JWKS endpoint. It should
+     * conform to the `HttpAgent` interface from node's `http` module or 
+     * the `HttpsAgent` interface from node's `https` module. 
      * 
-     * @deprecated use `requestAgent` instead
-     */
-    requestAgentOptions?: HttpAgentOptions | HttpsAgentOptions;
-
-    /**
-     * HttpAgent or HttpsAgent to use for requests to the JWKS endpoint. 
+     * Read more: https://nodejs.org/api/http.html#class-httpagent
      * Agent example: https://github.com/TooTallNate/node-https-proxy-agent
      */
     requestAgent?: HttpAgent | HttpsAgent;

--- a/lib.js
+++ b/lib.js
@@ -187,7 +187,6 @@ class OktaJwtVerifier {
       cacheMaxEntries: 3,
       jwksRequestsPerMinute: options.jwksRequestsPerMinute || 10,
       rateLimit: true,
-      requestAgentOptions: options.requestAgentOptions,
       requestAgent: options.requestAgent
     });
     this.verifier = nJwt.createVerifier().setSigningAlgorithm('RS256').withKeyResolver((kid, cb) => {

--- a/lib.js
+++ b/lib.js
@@ -188,6 +188,7 @@ class OktaJwtVerifier {
       jwksRequestsPerMinute: options.jwksRequestsPerMinute || 10,
       rateLimit: true,
       requestAgentOptions: options.requestAgentOptions,
+      requestAgent: options.requestAgent
     });
     this.verifier = nJwt.createVerifier().setSigningAlgorithm('RS256').withKeyResolver((kid, cb) => {
       if (kid) {


### PR DESCRIPTION
requestAgent will be forwarded to jwks-rsa client.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #26 

The `jwks-rsa` library has replaced the `requestAgentOptions` option with a new option called `requestAgent`. This option is used to specify a custom HTTP agent to be used when making requests to the JWKS endpoint. The agent can be any object that conforms to the Node.js `http.Agent` interface.

## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

It introduces a new feature and marks `requestAgentOptions` as deprecated which is no longer supported by jwks-rsa.

## Other information


## Reviewers

