### PR TITLE
Run PDV related tests based on condition

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,11 +5,10 @@ source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/reports/ci"
 
-export ISSUER=https://samples-javascript.okta.com/oauth2/default
-export CLIENT_ID=0oapmwm72082GXal14x6
-export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
-
+export ISSUER=https://sdk-test-ok14.okta.com/oauth2/default
+export CLIENT_ID=0oa5dztAOmaWJ09Dm694
+export USERNAME=alex@acme.com
+get_vault_secret_key devex/pdv/ok14 PASSWORD PASSWORD
 
 export CI=true
 export DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/test/internal-ci/token.spec.js
+++ b/test/internal-ci/token.spec.js
@@ -38,8 +38,11 @@ const issuer1TokenParams = {
   NONCE
 };
 
-describe('Access token test with api call', () => {
+// JWT_VERIFIER_REPO env var is only set in PDV script
+if (process.env.JWT_VERIFIER_REPO) describe.only('Running only PDV tests', () => {
+  console.warn('skipping non-PDV tests');
   const expectedAud = 'api://default';
+  const expectedClientId = CLIENT_ID;
   const verifier = createVerifier();
 
   it('should allow me to verify Okta access tokens', () => {
@@ -50,11 +53,24 @@ describe('Access token test with api call', () => {
     });
   }, LONG_TIMEOUT);
 
+  it('should allow me to verify Okta ID tokens', () => {
+    return getIdToken(issuer1TokenParams)
+    .then(idToken => {
+      return verifier.verifyIdToken(idToken, expectedClientId, NONCE);
+    })
+    .then(jwt => {
+      expect(jwt.claims.iss).toBe(ISSUER);
+    });
+  }, LONG_TIMEOUT);
+});
+
+describe('Access token test with api call', () => {
+  const expectedAud = 'api://default';
+  const verifier = createVerifier();
+
   it('should allow me to verify Okta access tokens', () => {
     return getAccessToken(issuer1TokenParams)
-    .then(accessToken => {
-      return verifier.verifyAccessToken(accessToken, expectedAud);
-    })
+    .then(accessToken => verifier.verifyAccessToken(accessToken, expectedAud))
     .then(jwt => {
       expect(jwt.claims.iss).toBe(ISSUER);
     });


### PR DESCRIPTION
- Currently, PDV runs all the tests in `token.spec.js`
- Most of the tests there are modifying a token returned by server, which doesn't really help with PDV
- This PR ensures only server minted token tests are run for PDV

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

