### PR TITLE
Fix: verifyAudience does not accept audience as an array

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -125,13 +125,18 @@ function verifyAudience(expected, aud) {
   if (!expected) {
     throw new Error('expected audience is required');
   }
-
-  if (Array.isArray(expected) && !expected.includes(aud)) {
-    throw new Error(`audience claim ${aud} does not match one of the expected audiences: ${expected.join(', ')}`);
-  }
-
-  if (!Array.isArray(expected) && aud !== expected) {
-    throw new Error(`audience claim ${aud} does not match expected audience: ${expected}`);
+  if (!Array.isArray(aud)) {
+    if (Array.isArray(expected) && !expected.includes(aud)) {
+      throw new Error(`audience claim ${aud} does not match one of the expected audiences: ${expected.join(', ')}`);
+    }
+  
+    if (!Array.isArray(expected) && aud !== expected) {
+      throw new Error(`audience claim ${aud} does not match expected audience: ${expected}`);
+    }
+  } else {
+    if (!aud.includes(expected)) {
+      throw new Error(`audience claims ${aud.join(', ')} do not include expected audience: ${expected}`);
+    }
   }
 }
 


### PR DESCRIPTION
Fix: `verifyAudience` does not accept audience as an array

Access tokens can have audience values that are arrays. This code currently doesn't support that. There is no way to match an audience array to an expected value

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

