### PR TITLE
breaking: removes `jwt.setXYZ` methods from .verify methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
+# 4.0.0
+
+### Breaking
+
+- [#47](https://github.com/okta/okta-jwt-verifier-js/pull/47) - **BREAKING CHANGE** `verifyAccessToken` and `verifyIdToken` no longer return an `njwt.Jwt` with setters (like `setIssuer` or `setSubject`). The resulting `jwt` is now frozen to prevent manipulation
+
 # 3.2.2
 
 ### Fixes
 
-- [46](https://github.com/okta/okta-jwt-verifier-js/pull/46) - Upgrades `njwt` version to `2.0.1` to pull in [CVE-2024-34273](https://www.cve.org/CVERecord?id=CVE-2024-34273) resolution
+- [#46](https://github.com/okta/okta-jwt-verifier-js/pull/46) - Upgrades `njwt` version to `2.0.1` to pull in [CVE-2024-34273](https://www.cve.org/CVERecord?id=CVE-2024-34273) resolution
 
 # 3.2.1
 
 ### Fixes
 
-- [45](https://github.com/okta/okta-jwt-verifier-js/pull/45) - freezes `njwt` version
+- [#45](https://github.com/okta/okta-jwt-verifier-js/pull/45) - freezes `njwt` version
 
 # 3.2.0
 

--- a/README.md
+++ b/README.md
@@ -130,13 +130,6 @@ The expected client ID passed to `verifyIdToken()` is required. Expected nonce v
     at_hash: 'at_hash'
   },
   toString: () => 'base64-encoded token',
-  setClaim: (claim, value) => token,
-  setJti: (jti) => token,
-  setSubject: (sub) => token,
-  setIssuer: (iss) => token,
-  setIssuedAt: (iat) => token,
-  setExpiration: (exp) => token,
-  setNotBefore: (nbf) => token,
   isExpired: () => Boolean,
   isNotBefore: () => Boolean,
 ```

--- a/lib.js
+++ b/lib.js
@@ -17,9 +17,6 @@ class ConfigurationValidationError extends Error {}
 
 const findDomainURL = 'https://bit.ly/finding-okta-domain';
 const findAppCredentialsURL = 'https://bit.ly/finding-okta-app-credentials';
-const njwtTokenBodyMethods = [
-  'setClaim', 'setJti', 'setSubject', 'setIssuer', 'setIssuedAt',
-  'setExpiration', 'setNotBefore', 'isExpired', 'isNotBefore'];
 
 const assertIssuer = (issuer, testing = {}) => {
   const isHttps = new RegExp('^https://');
@@ -230,26 +227,14 @@ class OktaJwtVerifier {
 
         const oktaJwt = {
           header: { ...jwt.header },
+          claims: { ...jwt.body },
           toString: () => tokenString,
+          isExpired: () => jwt.isExpired(),
+          isNotBefore: () => jwt.isNotBefore()
         };
 
-        const jwtBodyProxy = new Proxy(jwt.body, {});
-        Object.defineProperty(oktaJwt, 'claims', {
-          enumerable: true,
-          writable: false,
-          value: jwtBodyProxy
-        });
-
-        njwtTokenBodyMethods.forEach(method => {
-          const fn = jwt[method];
-          if (fn) {
-            oktaJwt[method] = fn.bind({ body: jwtBodyProxy })
-          }
-        });
-
         Object.freeze(oktaJwt.header);
-        // TODO: cannot be frozen without breaking change
-        // Object.freeze(oktaJwt.body);
+        Object.freeze(oktaJwt.claims);
         Object.freeze(oktaJwt);
 
         resolve(oktaJwt);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/jwt-verifier",
   "private": true,
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Easily validate Okta access tokens",
   "repository": "https://github.com/okta/okta-jwt-verifier-js",
   "homepage": "https://github.com/okta/okta-jwt-verifier-js",

--- a/test/spec/verify_id_token.spec.js
+++ b/test/spec/verify_id_token.spec.js
@@ -394,17 +394,20 @@ describe('Jwt Verifier - Verify ID Token', () => {
     it('has readonly \'claims\' property', () => {
       jwt.claims = { aud: 'defaultAPI' };
       expect(jwt.claims.aud).toEqual('0oaoesxtxmPf08QHk0h7');
+      expect(Object.isFrozen(jwt.header)).toBe(true);
+      expect(Object.isFrozen(jwt.claims)).toBe(true);
+      expect(Object.isFrozen(jwt)).toBe(true);
     });
 
-    it('tracks mutations done by claims accessors in the \'claims\' property', () => {
-      jwt.setClaim('customClaim', 'claimValue');
-      expect(jwt.claims.customClaim).toEqual('claimValue');
-
-      jwt.setClaim('exp', (new Date() - 1) / 1000);
-      expect(jwt.isExpired()).toBe(true);
-
-      jwt.setIssuer('foobar');
-      expect(jwt.claims.iss).toBe('foobar');
+    it('should not allow manipulation of verified jwt', () => {
+      expect(() => jwt.setClaim('customClaim', 'claimValue')).toThrow();
+      expect(() => jwt.setClaim('exp', (new Date() - 1) / 1000)).toThrow();
+      expect(() => jwt.setJti('foobar')).toThrow();
+      expect(() => jwt.setSubject('foobar')).toThrow();
+      expect(() => jwt.setIssuer('foobar')).toThrow();
+      expect(() => jwt.setIssuedAt('foobar')).toThrow();
+      expect(() => jwt.setExpiration('foobar')).toThrow();
+      expect(() => jwt.setNotBefore('foobar')).toThrow();
     });
   })
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

