### PR TITLE
fix: getKeysInterceptor type

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -127,7 +127,7 @@ declare namespace OktaJwtVerifier {
      * This option is passed to the `JwksClient` constructor. Useful when wanting to load key sets from a file, env variable or external cache
      * Read more: https://github.com/auth0/node-jwks-rsa/blob/master/EXAMPLES.md#loading-keys-from-local-file-environment-variable-or-other-externals
      */
-    getKeysInterceptor?(): Promise<JSONWebKey>;
+    getKeysInterceptor?(): Promise<JSONWebKey[]>;
   }
 
   type Algorithm =


### PR DESCRIPTION
The current signature didn't match `jwks-rsa`'s [signature](https://github.com/auth0/node-jwks-rsa/blob/master/index.d.ts#L34C28-L34C49).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I don't think the last two are relevant for this fix.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Assumes you can only provide one key.

Issue Number: N/A


## What is the new behavior?
Behavior matching `jwks-rsa`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

