### PR TITLE
fix: Add `testing` option to `VerifierOptions`

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -49,6 +49,10 @@ declare class OktaJwtVerifier {
 }
 
 declare namespace OktaJwtVerifier {
+  interface TestingOptions {
+    disableHttpsCheck: boolean;
+  }
+
   interface VerifierOptions {
     /**
      * Issuer/Authorization server URL
@@ -128,6 +132,8 @@ declare namespace OktaJwtVerifier {
      * Read more: https://github.com/auth0/node-jwks-rsa/blob/master/EXAMPLES.md#loading-keys-from-local-file-environment-variable-or-other-externals
      */
     getKeysInterceptor?(): Promise<JSONWebKey[]>;
+
+    testing?: TestingOptions;
   }
 
   type Algorithm =


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
It seems the testing option is missing from the `VerifierOptions` interface. `tsc` has an issue with this when type checking our code, also it is being used in the code base, so for clarity it would be nice to have this. The alternative would be supressing the error coming from tsc I suppose, however it's not a great thing to expect for all projects implementing this lib.

Issue Number: N/A


## What is the new behavior?
The interface has a reference to the `testing` option.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No